### PR TITLE
Add twist_mux to package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
+  <depend>twist_mux</depend>
   <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>


### PR DESCRIPTION
Twist_mux was not listed as a dependency in the package.xml file. I added it.